### PR TITLE
Update vehicle.py

### DIFF
--- a/pycrash/vehicle.py
+++ b/pycrash/vehicle.py
@@ -60,8 +60,8 @@ input_query = ["Model year",
 "notes"]
 
 veh_inputs = ["year",
-"make",
-"model",
+"vehmake",
+"vehmodel",
 "weight",
 "vin",
 "brake",


### PR DESCRIPTION
Adding in "veh" prefix to "make" and "model" input keys - downstream effects cause a bug in the "impact_main" __init__ function where the dataframes are oftentimes not written